### PR TITLE
修复机器注册名问题（详见描述，已提交issue）

### DIFF
--- a/EnigTech2/minecraft/scripts/crafttweaker/expert/mods/modularMachinery/mana_extractor.zs
+++ b/EnigTech2/minecraft/scripts/crafttweaker/expert/mods/modularMachinery/mana_extractor.zs
@@ -1,6 +1,6 @@
 #packmode expert
 #priority -100
-var machineName = "magic_extractor";
+var machineName = "mana_extractor";
 
 mods.modularmachinery.RecipeBuilder.newBuilder(machineName + "_default", machineName, 200)
 	.addItemInput(<embers:ember_cluster>)


### PR DESCRIPTION
修复注册名与config\modularmachinery\machinery\mana_extractor.json不一致导致合成表不加载的问题