### PR TITLE
抹杀Forge Microblocks石棒的存在

### DIFF
--- a/EnigTech2/minecraft/scripts/crafttweaker/expert/vanilla/StageTwo/removes.zs
+++ b/EnigTech2/minecraft/scripts/crafttweaker/expert/vanilla/StageTwo/removes.zs
@@ -79,5 +79,6 @@ recipes.remove(<embers:ingot_copper>);
 recipes.remove(<forestry:resource_storage>);
 recipes.remove(<astralsorcery:itemwand>.withTag({astralsorcery: {}}));
 recipes.remove(<silentgems:chaosorb:1>);
+recipes.removeByRecipeName("microblockcbe:stone_rod");
 
 recipes.removeByRegex("immersiveengineering:material/plate_.*");

--- a/EnigTech2/minecraft/scripts/crafttweaker/expert/vanilla/ore_dictionary.zs
+++ b/EnigTech2/minecraft/scripts/crafttweaker/expert/vanilla/ore_dictionary.zs
@@ -13,3 +13,5 @@
 <ore:blockApatite>.remove(<forestry:resource_storage>);
 //移除 林业模组 灰烬 的矿物词典
 <ore:dustAsh>.remove(<forestry:ash>);
+//抹杀 Forge Microblocks模组 石棒 的存在
+<ore:rodStone>.remove(<microblockcbe:stone_rod>);

--- a/EnigTech2/minecraft/scripts/crafttweaker/normal/vanilla/StageTwo/removes.zs
+++ b/EnigTech2/minecraft/scripts/crafttweaker/normal/vanilla/StageTwo/removes.zs
@@ -79,5 +79,6 @@ recipes.remove(<embers:ingot_copper>);
 recipes.remove(<forestry:resource_storage>);
 recipes.remove(<astralsorcery:itemwand>.withTag({astralsorcery: {}}));
 recipes.remove(<silentgems:chaosorb:1>);
+recipes.removeByRecipeName("microblockcbe:stone_rod");
 
 recipes.removeByRegex("immersiveengineering:material/plate_.*");

--- a/EnigTech2/minecraft/scripts/crafttweaker/normal/vanilla/ore_dictionary.zs
+++ b/EnigTech2/minecraft/scripts/crafttweaker/normal/vanilla/ore_dictionary.zs
@@ -13,3 +13,5 @@
 <ore:blockApatite>.remove(<forestry:resource_storage>);
 //移除 林业模组 灰烬 的矿物词典
 <ore:dustAsh>.remove(<forestry:ash>);
+//抹杀 Forge Microblocks模组 石棒 的存在
+<ore:rodStone>.remove(<microblockcbe:stone_rod>);


### PR DESCRIPTION
该石棒配方为2圆石=1石棒 不合理且与寂宝石棒冲突 索性移除之 现在所有三种手锯都将用寂宝石棒来合成且FMB石棒将不会显示在三种手锯的JEI配方中