### PR TITLE
Revert "（共同提议）普通模式修改crystaline高炉原料为意志晶体取代意志"

### DIFF
--- a/EnigTech2/minecraft/scripts/crafttweaker/normal/mods/modularMachinery/blast_furnace_mk1.zs
+++ b/EnigTech2/minecraft/scripts/crafttweaker/normal/mods/modularMachinery/blast_furnace_mk1.zs
@@ -146,10 +146,10 @@ mods.modularmachinery.RecipeBuilder.newBuilder(machineName + "_itemcraftingcompo
 mods.modularmachinery.RecipeBuilder.newBuilder(machineName + "_crystaline", machineName, speedTierThree)
 	.addManaInput(20000)
 	.addItemOutput(<extendedcrafting:material:24>*2)
-	.addItemInput(<bloodmagic:item_demon_crystal:4>)
-	.addItemInput(<bloodmagic:item_demon_crystal:3>)
-    .addItemInput(<bloodmagic:item_demon_crystal:2>)
-    .addItemInput(<bloodmagic:item_demon_crystal:1>)
+	.addItemInput(<bloodmagic:monster_soul:4>)
+	.addItemInput(<bloodmagic:monster_soul:3>)
+    .addItemInput(<bloodmagic:monster_soul:2>)
+    .addItemInput(<bloodmagic:monster_soul:1>)
     .addFluidInput(<liquid:fluid_dragon_breathe>*500)
 	.build();
 

--- a/EnigTech2/minecraft/scripts/crafttweaker/normal/mods/modularMachinery/blast_furnace_mk2.zs
+++ b/EnigTech2/minecraft/scripts/crafttweaker/normal/mods/modularMachinery/blast_furnace_mk2.zs
@@ -177,10 +177,10 @@ mods.modularmachinery.RecipeBuilder.newBuilder(machineName + "_AlTi", machineNam
 mods.modularmachinery.RecipeBuilder.newBuilder(machineName + "_crystaline", machineName, speedTierThree)
 	.addManaInput(20000)
 	.addItemOutput(<extendedcrafting:material:24>*2)
-	.addItemInput(<bloodmagic:item_demon_crystal:4>)
-	.addItemInput(<bloodmagic:item_demon_crystal:3>)
-    .addItemInput(<bloodmagic:item_demon_crystal:2>)
-    .addItemInput(<bloodmagic:item_demon_crystal:1>)
+	.addItemInput(<bloodmagic:monster_soul:4>)
+	.addItemInput(<bloodmagic:monster_soul:3>)
+    .addItemInput(<bloodmagic:monster_soul:2>)
+    .addItemInput(<bloodmagic:monster_soul:1>)
     .addFluidInput(<liquid:fluid_dragon_breathe>*500)
 	.build();
 

--- a/EnigTech2/minecraft/scripts/crafttweaker/normal/mods/modularMachinery/blast_furnace_mk3.zs
+++ b/EnigTech2/minecraft/scripts/crafttweaker/normal/mods/modularMachinery/blast_furnace_mk3.zs
@@ -177,10 +177,10 @@ mods.modularmachinery.RecipeBuilder.newBuilder(machineName + "_AlTi", machineNam
 mods.modularmachinery.RecipeBuilder.newBuilder(machineName + "_crystaline", machineName, speedTierThree)
 	.addManaInput(20000)
 	.addItemOutput(<extendedcrafting:material:24>*3)
-	.addItemInput(<bloodmagic:item_demon_crystal:4>)
-	.addItemInput(<bloodmagic:item_demon_crystal:3>)
-    .addItemInput(<bloodmagic:item_demon_crystal:2>)
-    .addItemInput(<bloodmagic:item_demon_crystal:1>)
+	.addItemInput(<bloodmagic:monster_soul:4>)
+	.addItemInput(<bloodmagic:monster_soul:3>)
+    .addItemInput(<bloodmagic:monster_soul:2>)
+    .addItemInput(<bloodmagic:monster_soul:1>)
     .addFluidInput(<liquid:fluid_dragon_breathe>*1000)
 	.build();
 

--- a/EnigTech2/minecraft/scripts/crafttweaker/normal/mods/modularMachinery/blast_furnace_mk4.zs
+++ b/EnigTech2/minecraft/scripts/crafttweaker/normal/mods/modularMachinery/blast_furnace_mk4.zs
@@ -177,10 +177,10 @@ mods.modularmachinery.RecipeBuilder.newBuilder(machineName + "_AlTi", machineNam
 mods.modularmachinery.RecipeBuilder.newBuilder(machineName + "_crystaline", machineName, speedTierThree)
 	.addManaInput(20000)
 	.addItemOutput(<extendedcrafting:material:24>*3)
-	.addItemInput(<bloodmagic:item_demon_crystal:4>)
-	.addItemInput(<bloodmagic:item_demon_crystal:3>)
-    .addItemInput(<bloodmagic:item_demon_crystal:2>)
-    .addItemInput(<bloodmagic:item_demon_crystal:1>)
+	.addItemInput(<bloodmagic:monster_soul:4>)
+	.addItemInput(<bloodmagic:monster_soul:3>)
+    .addItemInput(<bloodmagic:monster_soul:2>)
+    .addItemInput(<bloodmagic:monster_soul:1>)
     .addFluidInput(<liquid:fluid_dragon_breathe>*1000)
 	.build();
 

--- a/EnigTech2/minecraft/scripts/crafttweaker/normal/mods/modularMachinery/blast_furnace_mk5.zs
+++ b/EnigTech2/minecraft/scripts/crafttweaker/normal/mods/modularMachinery/blast_furnace_mk5.zs
@@ -177,10 +177,10 @@ mods.modularmachinery.RecipeBuilder.newBuilder(machineName + "_AlTi", machineNam
 mods.modularmachinery.RecipeBuilder.newBuilder(machineName + "_crystaline", machineName, speedTierThree)
 	.addManaInput(20000)
 	.addItemOutput(<extendedcrafting:material:24>*4)
-	.addItemInput(<bloodmagic:item_demon_crystal:4>)
-	.addItemInput(<bloodmagic:item_demon_crystal:3>)
-    .addItemInput(<bloodmagic:item_demon_crystal:2>)
-    .addItemInput(<bloodmagic:item_demon_crystal:1>)
+	.addItemInput(<bloodmagic:monster_soul:4>)
+	.addItemInput(<bloodmagic:monster_soul:3>)
+    .addItemInput(<bloodmagic:monster_soul:2>)
+    .addItemInput(<bloodmagic:monster_soul:1>)
     .addFluidInput(<liquid:fluid_dragon_breathe>*1000)
 	.build();
 


### PR DESCRIPTION
经过更进一层次的游玩体验发现获得纯意志的难度低于获得晶体的难度 应用于普通模式显得不合时宜 是否将此改动实现在专家模式 任君选择 此处先行回调