### PR TITLE
矿机合成微调

### DIFF
--- a/EnigTech2/minecraft/scripts/crafttweaker/normal/mods/environmentalTech/crystals.zs
+++ b/EnigTech2/minecraft/scripts/crafttweaker/normal/mods/environmentalTech/crystals.zs
@@ -1,0 +1,41 @@
+#packmode normal
+#modloaded etutil
+#priority -100
+
+import crafttweaker.item.IItemStack;
+import crafttweaker.item.IIngredient;
+
+//添加莱泽尔，艾洛蒂，凯罗尼，普雷蒂，艾恩尼，以太石的新合成方式
+recipes.addShaped(<environmentaltech:litherite>, [
+    [<environmentaltech:litherite_crystal>, <environmentaltech:litherite_crystal>, <environmentaltech:litherite_crystal>],
+    [<environmentaltech:litherite_crystal>, <ore:dustCrystalBinder>, <environmentaltech:litherite_crystal>],
+    [<environmentaltech:litherite_crystal>, <environmentaltech:litherite_crystal>, <environmentaltech:litherite_crystal>]]);
+recipes.addShaped(<environmentaltech:erodium>, [
+    [<environmentaltech:erodium_crystal>, <environmentaltech:erodium_crystal>, <environmentaltech:erodium_crystal>],
+    [<environmentaltech:erodium_crystal>, <ore:dustCrystalBinder>, <environmentaltech:erodium_crystal>],
+    [<environmentaltech:erodium_crystal>, <environmentaltech:erodium_crystal>, <environmentaltech:erodium_crystal>]]);
+recipes.addShaped(<environmentaltech:kyronite>, [
+    [<environmentaltech:kyronite_crystal>, <environmentaltech:kyronite_crystal>, <environmentaltech:kyronite_crystal>],
+    [<environmentaltech:kyronite_crystal>, <ore:dustCrystalBinder>, <environmentaltech:kyronite_crystal>],
+    [<environmentaltech:kyronite_crystal>, <environmentaltech:kyronite_crystal>, <environmentaltech:kyronite_crystal>]]);
+recipes.addShaped(<environmentaltech:pladium>, [
+    [<environmentaltech:pladium_crystal>, <environmentaltech:pladium_crystal>, <environmentaltech:pladium_crystal>],
+    [<environmentaltech:pladium_crystal>, <ore:dustCrystalBinder>, <environmentaltech:pladium_crystal>],
+    [<environmentaltech:pladium_crystal>, <environmentaltech:pladium_crystal>, <environmentaltech:pladium_crystal>]]);
+recipes.addShaped(<environmentaltech:ionite>, [
+    [<environmentaltech:ionite_crystal>, <environmentaltech:ionite_crystal>, <environmentaltech:ionite_crystal>],
+    [<environmentaltech:ionite_crystal>, <ore:dustCrystalBinder>, <environmentaltech:ionite_crystal>],
+    [<environmentaltech:ionite_crystal>, <environmentaltech:ionite_crystal>, <environmentaltech:ionite_crystal>]]);
+recipes.addShaped(<environmentaltech:aethium>, [
+    [<environmentaltech:aethium_crystal>, <environmentaltech:aethium_crystal>, <environmentaltech:aethium_crystal>],
+    [<environmentaltech:aethium_crystal>, <ore:dustCrystalBinder>, <environmentaltech:aethium_crystal>],
+    [<environmentaltech:aethium_crystal>, <environmentaltech:aethium_crystal>, <environmentaltech:aethium_crystal>]]);
+
+//玉 碎
+<bloodarsenal:glass_shards>.addTooltip("好像有什么东西碎掉了");
+recipes.addShapeless("breakLitherite", <bloodarsenal:glass_shards> * 16, [<environmentaltech:litherite>]);
+recipes.addShapeless("breakErodium", <bloodarsenal:glass_shards> * 16, [<environmentaltech:erodium>]);
+recipes.addShapeless("breakKyronite", <bloodarsenal:glass_shards> * 16, [<environmentaltech:kyronite>]);
+recipes.addShapeless("breakPladium", <bloodarsenal:glass_shards> * 16, [<environmentaltech:pladium>]);
+recipes.addShapeless("breakIonite", <bloodarsenal:glass_shards> * 16, [<environmentaltech:ionite>]);
+recipes.addShapeless("breakAethium", <bloodarsenal:glass_shards> * 16, [<environmentaltech:aethium>]);

--- a/EnigTech2/minecraft/scripts/crafttweaker/normal/mods/environmentalTech/remove.zs
+++ b/EnigTech2/minecraft/scripts/crafttweaker/normal/mods/environmentalTech/remove.zs
@@ -1,0 +1,25 @@
+#packmode normal
+#modloaded etutil
+#priority 0
+
+//移除所有矿机核心工作台配方
+recipes.remove(<environmentaltech:void_ore_miner_cont_1>);
+recipes.remove(<environmentaltech:void_ore_miner_cont_2>);
+recipes.remove(<environmentaltech:void_ore_miner_cont_3>);
+recipes.remove(<environmentaltech:void_ore_miner_cont_4>);
+recipes.remove(<environmentaltech:void_ore_miner_cont_5>);
+recipes.remove(<environmentaltech:void_ore_miner_cont_6>);
+
+//移除莱泽尔，艾洛蒂，凯罗尼，普雷蒂，艾恩尼，以太水晶/石的合成方式
+recipes.remove(<environmentaltech:litherite_crystal>);
+recipes.remove(<environmentaltech:litherite>);
+recipes.remove(<environmentaltech:erodium_crystal>);
+recipes.remove(<environmentaltech:erodium>);
+recipes.remove(<environmentaltech:kyronite_crystal>);
+recipes.remove(<environmentaltech:kyronite>);
+recipes.remove(<environmentaltech:pladium_crystal>);
+recipes.remove(<environmentaltech:pladium>);
+recipes.remove(<environmentaltech:ionite_crystal>);
+recipes.remove(<environmentaltech:ionite>);
+recipes.remove(<environmentaltech:aethium_crystal>);
+recipes.remove(<environmentaltech:aethium>);

--- a/EnigTech2/minecraft/scripts/crafttweaker/normal/mods/extendedCrafting/combination.zs
+++ b/EnigTech2/minecraft/scripts/crafttweaker/normal/mods/extendedCrafting/combination.zs
@@ -1,0 +1,41 @@
+#packmode normal expert
+#modloaded etutil
+#priority -100
+
+//导包
+import crafttweaker.item.IItemStack;
+
+/*
+mods.extendedcrafting.CombinationCrafting.addRecipe(<output>, rfCost, <input>,
+    [<pedestalItem>, <pedestalItem>]);
+
+mods.extendedcrafting.CombinationCrafting.addRecipe(<output>, rfCost, rfRate, <input>,
+    [<pedestalItem>, <pedestalItem>]);
+powerRate可选,若不填则读取配置
+Example:
+mods.extendedcrafting.CombinationCrafting.addRecipe(<minecraft:stick> * 10, 10000, 100,
+    <minecraft:diamond>, [<ore:ingotIron>, <minecraft:stick>]);
+*/
+
+//莱泽尔石
+mods.extendedcrafting.CombinationCrafting.addRecipe(<environmentaltech:litherite>, 100000,
+    <environmentaltech:litherite_crystal>, [<ore:blockBeryl>, <roots:cloud_berry>, <ore:dyeGreen>, <embers:crystal_ember>, <ore:elvenDragonstone>]);
+//艾洛蒂石
+mods.extendedcrafting.CombinationCrafting.addRecipe(<environmentaltech:erodium>, 100000,
+    <environmentaltech:litherite_crystal>, [<ore:blockAmethyst>, <roots:pereskia>, <ore:dyeMagenta>, <embers:crystal_ember>, <ore:elvenDragonstone>]);
+ 
+//凯罗尼石
+mods.extendedcrafting.CombinationCrafting.addRecipe(<environmentaltech:kyronite>, 100000,
+    <environmentaltech:erodium_crystal>, [<ore:blockAgate>, <roots:moonglow_leaf>, <ore:dyePurple>, <embers:crystal_ember>, <ore:elvenDragonstone>]);
+ 
+//普雷蒂石
+mods.extendedcrafting.CombinationCrafting.addRecipe(<environmentaltech:pladium>, 100000,
+    <environmentaltech:kyronite_crystal>, [<ore:blockBlueTopaz>, <roots:dewgonia>, <ore:dyeBlue>, <embers:crystal_ember>, <ore:elvenDragonstone>]);
+ 
+//艾恩尼石
+mods.extendedcrafting.CombinationCrafting.addRecipe(<environmentaltech:ionite>, 100000,
+    <environmentaltech:pladium_crystal>, [<ore:blockBlueTopaz>, <ore:ingotPrismarinium>, <ore:dyeLightBlue>, <embers:crystal_ember>, <ore:elvenDragonstone>]);
+ 
+//以太石
+mods.extendedcrafting.CombinationCrafting.addRecipe(<environmentaltech:aethium>, 100000,
+    <environmentaltech:aethium_crystal>, [<ore:blockBlackDiamond>, <ore:ingotBlackIron>, <ore:dyeBlack>, <embers:crystal_ember>, <ore:elvenDragonstone>]);

--- a/EnigTech2/minecraft/scripts/crafttweaker/normal/mods/extendedCrafting/ender.zs
+++ b/EnigTech2/minecraft/scripts/crafttweaker/normal/mods/extendedCrafting/ender.zs
@@ -1,0 +1,55 @@
+#packmode normal expert
+#modloaded etutil
+#priority -100
+
+import crafttweaker.item.IItemStack;
+import crafttweaker.item.IIngredient;
+
+/*
+Shaped:
+ mods.extendedcrafting.EnderCrafting.addShaped(<output>, [[<>, <>, <>], [<>, <>, <>], [<>, <>, <>]], seconds); 
+Shapeless
+ mods.extendedcrafting.EnderCrafting.addShapeless(<output>, [<input>, <input>, seconds]); 
+*/
+
+//环科一阶矿机核心
+mods.extendedcrafting.EnderCrafting.addShaped(<environmentaltech:void_ore_miner_cont_1>, [
+    [<ore:crystalLitherite>, <ore:blockDiamond>, <ore:crystalLitherite>],
+    [<ore:blockLitherite>, <environmentaltech:diode>, <ore:blockLitherite>],
+    [<ore:blockLitherite>, <ore:etLaserLens>, <ore:blockLitherite>]
+], 30);
+
+//环科二阶矿机核心
+mods.extendedcrafting.EnderCrafting.addShaped(<environmentaltech:void_ore_miner_cont_2>, [
+    [<ore:crystalErodium>, <ore:blockDiamond>, <ore:crystalErodium>],
+    [<ore:blockErodium>, <environmentaltech:void_ore_miner_cont_1>, <ore:blockErodium>],
+    [<ore:blockErodium>, <ore:etLaserLens>, <ore:blockErodium>]
+], 30);
+
+//环科三阶矿机核心
+mods.extendedcrafting.EnderCrafting.addShaped(<environmentaltech:void_ore_miner_cont_3>, [
+    [<ore:crystalKyronite>, <ore:blockDiamond>, <ore:crystalKyronite>],
+    [<ore:blockKyronite>, <environmentaltech:void_ore_miner_cont_2>, <ore:blockKyronite>],
+    [<ore:blockKyronite>, <ore:etLaserLens>, <ore:blockKyronite>]
+], 30);
+
+//环科四阶矿机核心
+mods.extendedcrafting.EnderCrafting.addShaped(<environmentaltech:void_ore_miner_cont_4>, [
+    [<ore:crystalPladium>, <ore:blockDiamond>, <ore:crystalPladium>],
+    [<ore:blockPladium>, <environmentaltech:void_ore_miner_cont_3>, <ore:blockPladium>],
+    [<ore:blockPladium>, <ore:etLaserLens>, <ore:blockPladium>]
+], 30);
+ 
+//环科五阶矿机核心
+mods.extendedcrafting.EnderCrafting.addShaped(<environmentaltech:void_ore_miner_cont_5>, [
+    [<ore:crystalIonite>, <ore:blockDiamond>, <ore:crystalIonite>],
+    [<ore:blockIonite>, <environmentaltech:void_ore_miner_cont_4>, <ore:blockIonite>],
+    [<ore:blockIonite>, <ore:etLaserLens>, <ore:blockIonite>]
+], 30);
+ 
+//环科六阶矿机核心
+mods.extendedcrafting.EnderCrafting.addShaped(<environmentaltech:void_ore_miner_cont_6>, [
+    [<ore:crystalAethium>, <ore:blockDiamond>, <ore:crystalAethium>],
+    [<ore:blockAethium>, <environmentaltech:void_ore_miner_cont_5>, <ore:blockAethium>],
+    [<ore:blockAethium>, <ore:etLaserLens>, <ore:blockAethium>]
+], 30);

--- a/EnigTech2/minecraft/scripts/crafttweaker/normal/mods/extendedCrafting/removes.zs
+++ b/EnigTech2/minecraft/scripts/crafttweaker/normal/mods/extendedCrafting/removes.zs
@@ -1,4 +1,5 @@
 #packmode normal
 #modloaded etutil
 #priority 0
+
 mods.extendedcrafting.TableCrafting.remove(<extendedcrafting:material:24>);


### PR DESCRIPTION
新增了环科的脚本文件夹，加入crystal.zs和remove.zs
在拓展合成的脚本文件夹中加入基座合成和末影合成的脚本(combination.zs,ender.zs)
修改了一到六阶虚空矿机核心的合成配方和方式，把所有矿机核心的配方迁移到末影合成
删除了环科水晶块→水晶的单项合成
将前几阶段的东西融合在一起并让宝石参与新的环科水晶石合成配方
复杂化了环科水晶石的工作台合成方式，激励玩家制作基座合成自动化，初始的两块莱泽尔石需要通复杂配方获得(NC水晶粘合剂)

最后强迫症发作把进阶合成的remove.zs加了个空行