### PR TITLE
修复 压缩抽屉不识别混沌煤

### DIFF
--- a/EnigTech2/minecraft/config/storagedrawers.cfg
+++ b/EnigTech2/minecraft/config/storagedrawers.cfg
@@ -208,6 +208,7 @@ registries {
         silentgems:craftingmaterial:4, silentgems:craftingmaterial:5, 9
         silentgems:miscblock:5, silentgems:craftingmaterial:4, 9
         silentgems:miscblock:0, silentgems:craftingmaterial:0, 9
+        silentgems:miscblock:3, silentgems:craftingmaterial:6, 9
         embers:crystal_ember, embers:shard_ember, 6
         teastory:half_dried_leaf_block, teastory:half_dried_tea, 9
         teastory:tea_leaf, teastory:broken_tea, 9


### PR DESCRIPTION
还有3个也是寂静宝石模组的方块好像也是不能被压缩抽屉识别，但应该不常用，如果强迫症需要的话我也可以做上。