### PR TITLE
修改森流仪式配方

### DIFF
--- a/EnigTech2/minecraft/scripts/crafttweaker/normal/mods/roots/rituals.zs
+++ b/EnigTech2/minecraft/scripts/crafttweaker/normal/mods/roots/rituals.zs
@@ -1,0 +1,7 @@
+#packmode normal
+#modloaded etutil
+#priority -100
+import mods.roots.Rituals;
+
+//森流祈愿
+Rituals.modifyRitual("grove_supplication", [<roots:cloud_berry>, <minecraft:mossy_cobblestone>, <ore:treeSapling>, <roots:wildroot>, <roots:petals>]);


### PR DESCRIPTION
1.6+更新roots版本之后，森流仪式需要木门合成，但在第一阶段无法合成原版的木门，同时获取野木也需要先进行森流仪式。 在此将木门的配方修改为之前版本的云莓。
进度的说明文字和相应的专家模式配方也需更改，具体方案由开发组决定。

> 你们做完不自己玩一遍吗（）我找野生木门找了好久